### PR TITLE
Make staging point to current production HEAD + github pages fix for testing

### DIFF
--- a/deploy/staging/config.json
+++ b/deploy/staging/config.json
@@ -1,6 +1,6 @@
 {
   "branch": "staging",
   "special_environment": "staging",
-  "head_sha": "89fddc660a5bd2f13d4a79a4f45c2e6303b5944a",
+  "head_sha": "d58698c21e9768c8c9eae675c8e3c05410c5ca7c",
   "host": "staging.pathoplexus.org"
 }


### PR DESCRIPTION
Revert "Bump staging to 89fddc660a5bd2f13d4a79a4f45c2e6303b5944a", bump staging to d58698c21e9768c8c9eae675c8e3c05410c5ca7c (https://github.com/pathoplexus/pathoplexus/pull/302)
Reverts pathoplexus/loculus_deployments#183