### PR TITLE
Point staging to current production HEAD

### DIFF
--- a/deploy/staging/config.json
+++ b/deploy/staging/config.json
@@ -1,6 +1,6 @@
 {
   "branch": "staging",
   "special_environment": "staging",
-  "head_sha": "b57aa79cde79aeea488e9507a445a6e7937ea920",
+  "head_sha": "f7a5cd299a484c15fcb55c8ea66ac1852c546215",
   "host": "staging.pathoplexus.org"
 }


### PR DESCRIPTION
In order to test the new rollout I want to (as always) reset staging to production by pointing both to the same commit and cloning the prod db to staging. 