### PR TITLE
Revert "Test updating single pipeline version"

### DIFF
--- a/deploy/staging/config.json
+++ b/deploy/staging/config.json
@@ -1,6 +1,6 @@
 {
   "branch": "staging",
   "special_environment": "staging",
-  "head_sha": "997fe162e2e7e7efbaf0e4a9194cadedb6919140",
+  "head_sha": "f46a0453f9326d8de01272b6af5452ae1f43544d",
   "host": "staging.pathoplexus.org"
 }


### PR DESCRIPTION
After testing (details in https://github.com/pathoplexus/pathoplexus/pull/411) I am relatively certain the multi-pipeline version PR is working as intended and we can revert this test and then promote staging to prod

Reverts pathoplexus/loculus_deployments#303