### PR TITLE
Revert "Bump staging to 7392c4"

### DIFF
--- a/deploy/staging/config.json
+++ b/deploy/staging/config.json
@@ -1,6 +1,6 @@
 {
   "branch": "staging",
   "special_environment": "staging",
-  "head_sha": "7392c4a96e1b278e3f3ad580d51d4ed327bf8db3",
+  "head_sha": "d29a679b3fb90af17fb814cd287ec10a670f96c6",
   "host": "staging.pathoplexus.org"
 }


### PR DESCRIPTION
See details in [Reverts pathoplexus/loculus_deployments#475](https://loculus.slack.com/archives/C05G172HL6L/p1757702842785739?thread_ts=1757671983.134249&cid=C05G172HL6L) - rsv updates are blocked due to one sequence that moved from rsv-a to rsv-b. Old version fails re-processing and moving sequence is not possible due to compression issues. 

We could delete the sequence in question but makes more sense to just wait to roll this out until we fix the compression issue