### PR TITLE
feat(actions): adding checklists to PRs created by deployment workflows

### DIFF
--- a/.github/workflows/bump-staging.yml
+++ b/.github/workflows/bump-staging.yml
@@ -73,3 +73,22 @@ jobs:
             
             ### Comparison
             https://github.com/pathoplexus/pathoplexus/compare/${{ steps.get_current_sha.outputs.CURRENT_SHA }}...${{ steps.get_commit_info.outputs.LATEST_SHA }}
+
+            ## Post-merge checklists
+
+            After merging this PR, work through these checks (or provide justification for anything that was skipped) to confirm functionality and data integrity of Pathoplexus under the new version.
+
+            ### Standard checklist:
+
+            - [ ] Run regression tests, highlight any observed differences here and discuss why they are expected. If the new version includes new preprocessing pipeline versions: wait for reprocessing to finish and for all new SILO pods to come up first
+            - [ ] Confirm submit/revise/revoke flow works:
+                - [ ] Submit test data to the staging preview
+                  - [ ] Confirm submission goes through (paste AccessionVersion(s) here)
+                - [ ] Revise a test sequence (paste AccessionVersion here)
+                  - [ ] Confirm revision goes through
+                - [ ] Revoke a test sequence (paste AccessionVersion here)
+                  - [ ] Confirm revocation goes through
+
+            ### Rollout-specific checklist:
+
+            Document any checks that were performed to test newly added features, database surgeries, etc. here.

--- a/.github/workflows/bump-staging.yml
+++ b/.github/workflows/bump-staging.yml
@@ -74,13 +74,21 @@ jobs:
             ### Comparison
             https://github.com/pathoplexus/pathoplexus/compare/${{ steps.get_current_sha.outputs.CURRENT_SHA }}...${{ steps.get_commit_info.outputs.LATEST_SHA }}
 
+            ## Pre-merge checklists
+
+            Before merging this PR and bumping the staging version, clone the production database to staging and confirm this was successful:
+
+            - [ ] DB clone: `ssh bastion "cd pathoplexus/scripts/db-clone/ && ./clone-prod-to-staging.sh"`
+            - [ ] Restart staging backend: `kubectl rollout restart deployment/loculus-backend -n staging`
+            - [ ] Run regressions tests to confirm staging is now identical to production (you will need to wait for SILO pods to import any new data)
+
             ## Post-merge checklists
 
             After merging this PR, work through these checks (or provide justification for anything that was skipped) to confirm functionality and data integrity of Pathoplexus under the new version.
 
             ### Standard checklist:
 
-            - [ ] Run regression tests, highlight any observed differences here and discuss why they are expected. If the new version includes new preprocessing pipeline versions: wait for reprocessing to finish and for all new SILO pods to come up first
+            - [ ] Run regression tests, highlight any observed differences and discuss why they are expected. If the new version includes new preprocessing pipeline versions: wait for reprocessing to finish and for all new SILO pods to come up first
             - [ ] Confirm submit/revise/revoke flow works:
                 - [ ] Submit test data to the staging preview
                   - [ ] Confirm submission goes through (paste AccessionVersion(s) here)

--- a/.github/workflows/bump-staging.yml
+++ b/.github/workflows/bump-staging.yml
@@ -89,12 +89,12 @@ jobs:
             ### Standard checklist:
 
             - [ ] Run regression tests, highlight any observed differences and discuss why they are expected. If the new version includes new preprocessing pipeline versions: wait for reprocessing to finish and for all new SILO pods to come up first
-            - [ ] Confirm submit/revise/revoke flow works:
+            - [ ] Confirm submit/revise/revoke flow works (also pay close attention to the UI, document anything out of the ordinary):
                 - [ ] Submit test data to the staging preview
-                  - [ ] Confirm submission goes through (paste AccessionVersion(s) here)
-                - [ ] Revise a test sequence (paste AccessionVersion here)
+                  - [ ] Confirm submission goes through (_paste AccessionVersion(s) here_)
+                - [ ] Revise a test sequence (_paste AccessionVersion here_)
                   - [ ] Confirm revision goes through
-                - [ ] Revoke a test sequence (paste AccessionVersion here)
+                - [ ] Revoke a test sequence (_paste AccessionVersion here_)
                   - [ ] Confirm revocation goes through
 
             ### Rollout-specific checklist:

--- a/.github/workflows/promote-staging-to-production.yml
+++ b/.github/workflows/promote-staging-to-production.yml
@@ -32,5 +32,10 @@ jobs:
             Staging SHA: ${{ steps.get_staging_sha.outputs.STAGING_SHA }}
             
             Please review and approve to deploy this version to production.
+
+            ## Pre-merge checklists
+
+            The PR opened by [the workflow to bump staging to the latest Pathoplexus version](https://github.com/pathoplexus/loculus_deployments/actions/workflows/bump-staging.yml) provides a checklists of what to test on staging before promoting staging to production. Please copy the completed checklist here so it can be reviewed.
+
           branch: promote-to-production-${{ steps.get_staging_sha.outputs.STAGING_SHA }}
           base: main

--- a/.github/workflows/promote-staging-to-production.yml
+++ b/.github/workflows/promote-staging-to-production.yml
@@ -35,7 +35,7 @@ jobs:
 
             ## Pre-merge checklists
 
-            The PR opened by [the workflow to bump staging to the latest Pathoplexus version](https://github.com/pathoplexus/loculus_deployments/actions/workflows/bump-staging.yml) provides a checklists of what to test on staging before promoting staging to production. Please copy the completed checklist here so it can be reviewed.
+            - [ ] The new Pathoplexus version was tested on staging with standard regression testing (_paste a link to the staging PR here_)
 
           branch: promote-to-production-${{ steps.get_staging_sha.outputs.STAGING_SHA }}
           base: main


### PR DESCRIPTION
We have two worflows to perform the two steps of a Pathoplexus rollout: [bump-staging.yml](https://github.com/pathoplexus/loculus_deployments/actions/workflows/bump-staging.yml) and [promote-staging-to-production.yml](https://github.com/pathoplexus/loculus_deployments/actions/workflows/promote-staging-to-production.yml).

This PR adds a checklist of steps to perform while a new Pathoplexus version is on staging to the PRs created by [bump-staging.yml](https://github.com/pathoplexus/loculus_deployments/actions/workflows/bump-staging.yml), and adds a sections to [promote-staging-to-production.yml](https://github.com/pathoplexus/loculus_deployments/actions/workflows/promote-staging-to-production.yml) that asks for the copleted version of this checklist. This should make reviewing these PRs easier and make it harder to forget testing steps when performing rollouts.

I ran [bump-staging.yml](https://github.com/pathoplexus/loculus_deployments/actions/workflows/bump-staging.yml) from this branch to check, this is what the resulting PR looked like (https://github.com/pathoplexus/loculus_deployments/pull/824, wording has changed slightly since this screenshot):

<img width="807" height="806" alt="image" src="https://github.com/user-attachments/assets/49cb5bed-fa18-4065-866c-6c428d277c1c" />
